### PR TITLE
Enable device tree generation and unified soc debugging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ Arguments
 <soc name>                  Custom soc name 
 <board name>                Custom board name
 <targeted device>           Targeted device, i.e. T120, Ti60 and Ti180
-<-m memory configuration>   [Optional] RAM memory (e.g. int (on-chip RAM), ext(DDR)). Default: int. 
+<-em>|<--extmemory>         [Optional] Select external RAM memory (DDR). 
                             Internal memory will be used if no external memory detected in soc.h even with external memory selected.
 
 Example,
-python3 dt-generator/zephyr_installer.py my_soc1 my_board1 ti60 ./zephyr/ ./dt-generator/soc.h -m int
+python3 dt-generator/zephyr_installer.py my_soc1 my_board1 ti60 ./zephyr/ ./dt-generator/soc.h -em
 ```
 
 - **The development environment Zephyr project with Efinix support is ready. You can now start developing and testing your project**

--- a/README.md
+++ b/README.md
@@ -68,7 +68,17 @@ Setup
     - Execute the following commands:
         - `cd /zephyr`
         - `./zephyr_efx_setup.sh` --> This script will pull the Zephyr project repo with Efinix board support
-
+    - To use your own SoC Configuration, follow the steps below; 
+        - Generate your own SoC with our Efinity IP Manager
+        - Locate the soc.h which will be available in `embedded_sw/<soc name>/bsp/efinix/EfxSapphireSoc/include/soc.h`
+        - Run `./dts_gen_setup.sh` --> This script will pull the dt-generator repo for automated device tree generation
+        - Copy the soc.h from your SoC folder into the dt-generator folder
+        - The dt-generator will help you to update all the necessary files with your SoC configuration
+        - Run the following command: 
+```
+python3 zephyr_installer.py <soc name> <board name> <targeted device> ./zephyr/ ./dt-generator/soc.h
+python3 dt-generator/zephyr_installer.py my_soc1 my_board1 ti60 ./zephyr/ ./dt-generator/soc.h
+```
 - **The development environment Zephyr project with Efinix support is ready. You can now start developing and testing your project**
 
 USBIP Setup for Windows:
@@ -93,11 +103,17 @@ Development Process
     - Refer to the [Sapphire RISC-V SoC Hardware and Software User Guide](https://www.efinixinc.com/support/docsdl.php?s=ef&pn=SAPPHIREUG) for guidance on creating your own SoC. Review Chapter 1, 2, and 3 of the User Guide to gain a thorough understanding of the customization process
 
 2. Obtain the Zephyr firmware by running the following command from the `/zephyr/zephyr` directory to build the "Hello World" sample project:
-
+    - If you are using standard configuration
 ```
 west build -b titanium_ti60_f225 samples/hello_world -p always
 
 ```
+   - if you are using own SoC Configuration
+```
+west build -b <board name>_<targeted device> samples/hello_world -p always
+west build -b my_board1_ti60 samples/hello_world -p always # Example
+
+``` 
 The resulting firmware will be located at `/zephyr/zephyr/build/zephyr/zephyr.bin`. Download the `zephyr.bin` file to your host machine.
 
 3. Combine both the bitstream and firmware, and flash the resulting image, Refer to the [Sapphire RISC-V SoC Hardware and Software User Guide](https://www.efinixinc.com/support/docsdl.php?s=ef&pn=SAPPHIREUG) , The Section `Copy a User Binary to Flash (Efinity Programmer)`

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Setup
         - `cd /zephyr`
         - `./zephyr_efx_setup.sh` --> This script will pull the Zephyr project repo with Efinix board support
         - `./soc_debugger_setup.sh` --> This script will pull SoC Debugger repo for debugging Efinix RISC-V Sapphire SoC into soc_debugger folder
-        > **_NOTE:_**     Use Command `sudo chmod 777 <script name>.sh` to allow the .sh script to be executable.
+        > ***Note:***     Use Command `sudo chmod 777 <script name>.sh` to allow the .sh script to be executable.
     - To use your own SoC Configuration, follow the steps below; 
         - Generate your own SoC with our Efinity IP Manager
         - Locate the soc.h which will be available in `embedded_sw/<soc name>/bsp/efinix/EfxSapphireSoc/include/soc.h`
@@ -78,9 +78,21 @@ Setup
         - The dt-generator will help you to update all the necessary files with your SoC configuration
         - Run the following command: 
 ```
-python3 zephyr_installer.py <soc name> <board name> <targeted device> ./zephyr/ ./dt-generator/soc.h
-python3 dt-generator/zephyr_installer.py my_soc1 my_board1 ti60 ./zephyr/ ./dt-generator/soc.h
+python3 zephyr_installer.py <soc name> <board name> <targeted device> ./zephyr/ ./dt-generator/soc.h <-m memory configuration>
 ```
+```
+Arguments
+
+<soc name>                  Custom soc name 
+<board name>                Custom board name
+<targeted device>           Targeted device, i.e. T120, Ti60 and Ti180
+<-m memory configuration>   [Optional] RAM memory (e.g. int (on-chip RAM), ext(DDR)). Default: int. 
+                            Internal memory will be used if no external memory detected in soc.h even with external memory selected.
+
+Example,
+python3 dt-generator/zephyr_installer.py my_soc1 my_board1 ti60 ./zephyr/ ./dt-generator/soc.h -m int
+```
+
 - **The development environment Zephyr project with Efinix support is ready. You can now start developing and testing your project**
 
 USBIP Setup for Windows:
@@ -91,6 +103,7 @@ USBIP Setup for Windows:
 2. Run `usbipd list` --> This command will list all the USB devices connected to the host machine, note down the BUS ID of the development board, it should be something like `Titanium Ti60F225 Development Kit`
 3. Run `usbipd wsl attach -b <BUS ID> --distribution Ubuntu-22.04` --> replace <BUS ID> with the actual BUS ID of the development board
 
+> ***Note:*** If your device is detected in the terminal but "no device found" error occur when launch debug, you may use the command `mount -t devtmpfs none /dev` to mount the USB to '/dev' directory
 
 Development Process
 --------------------
@@ -108,13 +121,13 @@ Development Process
     - If you are using standard configuration
 ```
 west build -b titanium_ti60_f225 samples/hello_world -p always
-
 ```
    - if you are using own SoC Configuration
 ```
 west build -b <board name>_<targeted device> samples/hello_world -p always
-west build -b my_board1_ti60 samples/hello_world -p always # Example
 
+Example; 
+west build -b my_board1_ti60 samples/hello_world -p always # Example
 ``` 
 The resulting firmware will be located at `/zephyr/zephyr/build/zephyr/zephyr.bin`. Download the `zephyr.bin` file to your host machine.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Setup
     - Execute the following commands:
         - `cd /zephyr`
         - `./zephyr_efx_setup.sh` --> This script will pull the Zephyr project repo with Efinix board support
+        - `./soc_debugger_setup.sh` --> This script will pull SoC Debugger repo for debugging Efinix RISC-V Sapphire SoC into soc_debugger folder
+        > **_NOTE:_**     Use Command `sudo chmod 777 <script name>.sh` to allow the .sh script to be executable.
     - To use your own SoC Configuration, follow the steps below; 
         - Generate your own SoC with our Efinity IP Manager
         - Locate the soc.h which will be available in `embedded_sw/<soc name>/bsp/efinix/EfxSapphireSoc/include/soc.h`

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -8,7 +8,20 @@ Ensure that:
 1. Launch the terminal in VS Code:
    - Use the command palette and enter `Terminal: Create New Terminal (In Active Workspace)`
 2. Run these commands in the terminal:
-   - `cd /zephyr/ && ./openocd_cfg/start_openocd.sh`  # This script initiates the openocd server
+
+   - `cd /zephyr/ && ./openocd_cfg/soc_debug.sh -b ti180 -c 4`  # This script initiates the openocd server
+```
+Usage
+
+-b, board       Board can be t120, ti60 or ti180
+-c, cpu count   Number of CPU. Default is 1
+-i, interface   Debug interface. Default is 1
+                1 - RISCV Standard Debug Interface
+                0 - Vexriscv Debug Interface
+-s, soft tap    Using soft tap instead of hard JTAG. Default is using
+                hard JTAG.
+-d, debug       Show debug message
+```
 3. Debug the application using VS Code:
    - Access the Command Palette by pressing `Ctrl + Shift + P`
    - Enter `Debug: Start Debugging`

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -9,19 +9,27 @@ Ensure that:
    - Use the command palette and enter `Terminal: Create New Terminal (In Active Workspace)`
 2. Run these commands in the terminal:
 
-   - `cd /zephyr/ && ./openocd_cfg/soc_debug.sh -b ti180 -c 4`  # This script initiates the openocd server
-```
+   - `cd /zephyr/ && ./soc_debugger/soc_debug.sh -b ti180 -c 4 -z`  # This script initiates the openocd server
+```bash
 Usage
 
--b, board       Board can be t120, ti60 or ti180
--c, cpu count   Number of CPU. Default is 1
--i, interface   Debug interface. Default is 1
-                1 - RISCV Standard Debug Interface
-                0 - Vexriscv Debug Interface
--s, soft tap    Using soft tap instead of hard JTAG. Default is using
-                hard JTAG.
--d, debug       Show debug message
+-b, board         Board can be t120, ti60 or ti180
+-c, cpu count     Number of CPU. Default is 1
+-i, interface     Debug interface. Default is 1
+                  1 - RISCV Standard Debug Interface
+                  0 - Vexriscv Debug Interface
+-s, soft tap      Using soft tap instead of hard JTAG. Default is using
+                  hard JTAG.
+-d, debug         Show debug message
+-z, Zephyr Debug  Enable debug for Zephyr 
+-l  Linux Debug   Enable debug for Linux 
+-t, Tap port      FPGA tap port number. Default is 1. Range is 1 to 4. 
+
+Example,
+./soc_debugger/soc_debug.sh -b ti180 -c 4 -z
+
 ```
+
 3. Debug the application using VS Code:
    - Access the Command Palette by pressing `Ctrl + Shift + P`
    - Enter `Debug: Start Debugging`

--- a/volume/assets/dts_gen_setup.sh
+++ b/volume/assets/dts_gen_setup.sh
@@ -1,4 +1,4 @@
-git clone -b zephyr_installer https://github.com/joo-jie/dt-generator.git # Use https://github.com/Efinix-Inc/dt-generator for official release
+git clone https://github.com/Efinix-Inc/dt-generator
 
 
 

--- a/volume/assets/dts_gen_setup.sh
+++ b/volume/assets/dts_gen_setup.sh
@@ -1,0 +1,5 @@
+git clone -b zephyr_installer https://github.com/joo-jie/dt-generator.git # Use https://github.com/Efinix-Inc/dt-generator for official release
+
+
+
+

--- a/volume/assets/soc_debugger_setup.sh
+++ b/volume/assets/soc_debugger_setup.sh
@@ -1,0 +1,1 @@
+git clone http://gitlab/mnalim/soc_debugger.git

--- a/volume/assets/soc_debugger_setup.sh
+++ b/volume/assets/soc_debugger_setup.sh
@@ -1,1 +1,1 @@
-git clone http://gitlab/mnalim/soc_debugger.git
+git clone https://github.com/Efinix-Inc/soc-debugger.git soc_debugger

--- a/volume/inits_scripts/initial_setup.sh
+++ b/volume/inits_scripts/initial_setup.sh
@@ -9,7 +9,26 @@ cd /zephyr && touch zephyr_efx_setup.sh && echo "west init -m https://github.com
 > zephyr_efx_setup.sh && chmod +x zephyr_efx_setup.sh && \
 echo -e "\e[32mZephyr init script created!!!!\e[0m\n"
 echo -e "\e[32mRun { cd /zephyr && ./zephyr_efx_setup.sh } - to setup zephyr repo\e[0m\n"
+
 fi
+
+if [ -e "/zephyr/dts_gen_setup.sh" ]; then
+    echo -e "\e[32mdts_gen_setup.sh already exists\e[0m\n"
+
+else
+echo -e "\e[32mCopying soc_debugger_setup.sh to /zepyhr....\e[0m\n"
+cp -r /app/zephyrrtos/assets/soc_debugger_setup.sh /zephyr && \
+echo -e "\e[32mDone copying soc_debugger_setup.sh to /zephyr!!!\e[0m\n"
+fi 
+
+if [ -e "/zephyr/dts_gen_setup.sh" ]; then
+    echo -e "\e[32mdts_gen_setup.sh already exists\e[0m\n"
+
+else
+echo -e "\e[32mCopying dts_gen_setup.sh to /zepyhr....\e[0m\n"
+cp -r /app/zephyrrtos/assets/dts_gen_setup.sh /zephyr && \
+echo -e "\e[32mDone copying dts_gen_setup.sh to /zephyr!!!\e[0m\n"
+fi 
 
 if [ -d "/zephyr/openocd_cfg" ]; then
     echo -e "\e[32mOpenocd config directory already exists\e[0m\n"


### PR DESCRIPTION
- Device tree can now be generated based on the imported soc.h. 
- OpenOCD debugging can now support all available Efinix Development Board (Previously only Ti60F225 Dev Kit) with the integration of soc-debugger repository. 
- All required readme updated. 